### PR TITLE
Shift the approach to updateble global HTAB.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DATA = pg_mentor--0.1.sql
 PGFILEDESC = "pg_mentor - manage query parameters"
 
 REGRESS_OPTS = --temp-config $(top_srcdir)/contrib/pg_mentor/pg_mentor.conf
-REGRESS = pg_mentor
+REGRESS = global_hash_table pg_mentor
 
 EXTRA_INSTALL = contrib/pg_stat_statements
 

--- a/expected/global_hash_table.out
+++ b/expected/global_hash_table.out
@@ -1,0 +1,117 @@
+CREATE EXTENSION pg_mentor CASCADE;
+NOTICE:  installing required extension "pg_stat_statements"
+SELECT 1 AS noname FROM pg_mentor_reset();
+ noname 
+--------
+      1
+(1 row)
+
+CREATE FUNCTION show_entries()
+RETURNS TABLE (
+  refcounter		integer,
+  plan_cache_mode	integer,
+  query				text
+)  AS $$
+BEGIN
+  RETURN QUERY
+    SELECT p.refcounter,p.plan_cache_mode,s.query
+    FROM pg_mentor_show_prepared_statements(-1) p JOIN
+	  pg_stat_statements s USING (queryid);
+END;
+$$ LANGUAGE PLPGSQL;
+-- Should show nothing. XXX: parallel tests may interfere here.
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode | query 
+------------+-----------------+-------
+(0 rows)
+
+-- Dummy test on redundant deallocation
+PREPARE stmt0(int) AS SELECT $1+random() AS x;
+PREPARE stmt1(int,int) AS SELECT $1+$2 AS x;
+PREPARE stmt2(int,int) AS SELECT sqrt($1+$2) AS x;
+-- Use \gset to hide the result
+EXECUTE stmt0(1) \gset
+EXECUTE stmt1(1,2) \gset
+EXECUTE stmt2(3,4) \gset
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          1 |               0 | SELECT $1+$2 AS x
+          1 |               0 | SELECT sqrt($1+$2) AS x
+          1 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+DEALLOCATE stmt0;
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          1 |               0 | SELECT $1+$2 AS x
+          1 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+DEALLOCATE stmt0;
+ERROR:  prepared statement "stmt0" does not exist
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          1 |               0 | SELECT $1+$2 AS x
+          1 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+DEALLOCATE ALL;
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          0 |               0 | SELECT $1+$2 AS x
+          0 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+DEALLOCATE ALL;
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          0 |               0 | SELECT $1+$2 AS x
+          0 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+-- Prepare statements before the exit
+PREPARE stmt1(int,int) AS SELECT $1+$2;
+PREPARE stmt2(int,int) AS SELECT sqrt($1+$2);
+-- see couple of used entries
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          1 |               0 | SELECT $1+$2 AS x
+          1 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+SELECT current_database() AS dbname \gset
+-- Let's open a new connection and see what we can find there
+\c :dbname
+-- exiting, backend cleans its refcounters - all the entries should be zeroed
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          0 |               0 | SELECT $1+$2 AS x
+          0 |               0 | SELECT sqrt($1+$2) AS x
+          0 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+PREPARE stmt0(int) AS SELECT $1+random();
+-- Check that the entry will be reused
+SELECT * FROM show_entries() ORDER BY md5(query);
+ refcounter | plan_cache_mode |          query          
+------------+-----------------+-------------------------
+          0 |               0 | SELECT $1+$2 AS x
+          0 |               0 | SELECT sqrt($1+$2) AS x
+          1 |               0 | SELECT $1+random() AS x
+(3 rows)
+
+DEALLOCATE ALL;
+DROP FUNCTION show_entries();
+DROP EXTENSION pg_mentor;

--- a/expected/pg_mentor.out
+++ b/expected/pg_mentor.out
@@ -1,5 +1,18 @@
 CREATE EXTENSION pg_mentor CASCADE;
-NOTICE:  installing required extension "pg_stat_statements"
+CREATE FUNCTION show_entries()
+RETURNS TABLE (
+  refcounter		integer,
+  plan_cache_mode	integer,
+  calls				bigint,
+  query				text
+)  AS $$
+BEGIN
+  RETURN QUERY
+    SELECT p.refcounter,p.plan_cache_mode,s.calls,s.query
+    FROM pg_mentor_show_prepared_statements(-1) p JOIN
+	  pg_stat_statements s USING (queryid);
+END;
+$$ LANGUAGE PLPGSQL;
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
 BEGIN
     RETURN QUERY
@@ -152,7 +165,7 @@ EXPLAIN (COSTS OFF) EXECUTE qry(1); -- it uses custom plan yet
 SELECT pg_mentor_nail_long_planned();
  pg_mentor_nail_long_planned 
 -----------------------------
-                           7
+                           4
 (1 row)
 
 EXPLAIN (COSTS OFF) EXECUTE qry(1); -- should be generic plan
@@ -163,6 +176,18 @@ EXPLAIN (COSTS OFF) EXECUTE qry(1); -- should be generic plan
    ->  Index Only Scan using part1_id_idx2 on part1 part_1
          Index Cond: (id = ANY (ARRAY[$1, ($1 + 1)]))
 (4 rows)
+
+SELECT refcounter,calls,plan_cache_mode,query
+FROM show_entries()
+ORDER BY md5(query);
+ refcounter | calls | plan_cache_mode |                   query                   
+------------+-------+-----------------+-------------------------------------------
+          1 |     8 |               1 | SELECT * FROM part WHERE id IN ($1, $1+1)
+          0 |     1 |               1 | SELECT $1+$2 AS x
+          0 |     1 |               1 | SELECT sqrt($1+$2) AS x
+          0 |     1 |               0 | SELECT $1+random() AS x
+          1 |     5 |               1 | SELECT * FROM test WHERE x = $1
+(5 rows)
 
 DEALLOCATE ALL;
 DROP TABLE test CASCADE;

--- a/sql/global_hash_table.sql
+++ b/sql/global_hash_table.sql
@@ -1,0 +1,59 @@
+CREATE EXTENSION pg_mentor CASCADE;
+SELECT 1 AS noname FROM pg_mentor_reset();
+
+CREATE FUNCTION show_entries()
+RETURNS TABLE (
+  refcounter		integer,
+  plan_cache_mode	integer,
+  query				text
+)  AS $$
+BEGIN
+  RETURN QUERY
+    SELECT p.refcounter,p.plan_cache_mode,s.query
+    FROM pg_mentor_show_prepared_statements(-1) p JOIN
+	  pg_stat_statements s USING (queryid);
+END;
+$$ LANGUAGE PLPGSQL;
+
+-- Should show nothing. XXX: parallel tests may interfere here.
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+-- Dummy test on redundant deallocation
+PREPARE stmt0(int) AS SELECT $1+random() AS x;
+PREPARE stmt1(int,int) AS SELECT $1+$2 AS x;
+PREPARE stmt2(int,int) AS SELECT sqrt($1+$2) AS x;
+-- Use \gset to hide the result
+EXECUTE stmt0(1) \gset
+EXECUTE stmt1(1,2) \gset
+EXECUTE stmt2(3,4) \gset
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+DEALLOCATE stmt0;
+SELECT * FROM show_entries() ORDER BY md5(query);
+DEALLOCATE stmt0;
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+DEALLOCATE ALL;
+SELECT * FROM show_entries() ORDER BY md5(query);
+DEALLOCATE ALL;
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+-- Prepare statements before the exit
+PREPARE stmt1(int,int) AS SELECT $1+$2;
+PREPARE stmt2(int,int) AS SELECT sqrt($1+$2);
+-- see couple of used entries
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+SELECT current_database() AS dbname \gset
+
+-- Let's open a new connection and see what we can find there
+\c :dbname
+-- exiting, backend cleans its refcounters - all the entries should be zeroed
+SELECT * FROM show_entries() ORDER BY md5(query);
+PREPARE stmt0(int) AS SELECT $1+random();
+-- Check that the entry will be reused
+SELECT * FROM show_entries() ORDER BY md5(query);
+
+DEALLOCATE ALL;
+DROP FUNCTION show_entries();
+DROP EXTENSION pg_mentor;

--- a/sql/pg_mentor.sql
+++ b/sql/pg_mentor.sql
@@ -1,5 +1,21 @@
 CREATE EXTENSION pg_mentor CASCADE;
 
+CREATE FUNCTION show_entries()
+RETURNS TABLE (
+  refcounter		integer,
+  plan_cache_mode	integer,
+  calls				bigint,
+  query				text
+)  AS $$
+BEGIN
+  RETURN QUERY
+    SELECT p.refcounter,p.plan_cache_mode,s.calls,s.query
+    FROM pg_mentor_show_prepared_statements(-1) p JOIN
+	  pg_stat_statements s USING (queryid);
+END;
+$$ LANGUAGE PLPGSQL;
+
+
 CREATE OR REPLACE FUNCTION expln(query_string text) RETURNS SETOF text AS $$
 BEGIN
     RETURN QUERY
@@ -37,7 +53,6 @@ EXPLAIN (COSTS OFF) EXECUTE stmt1(1); -- auto mode
 
 -- Prepare the case when custom plan cost all the time much less than the
 -- generic one
-SELECT count(*) FROM pg_stat_statements_reset();
 CREATE TABLE part (
 	id int
 ) PARTITION BY RANGE (id);
@@ -68,9 +83,8 @@ EXPLAIN (COSTS OFF) EXECUTE qry(1); -- it uses custom plan yet
 SELECT pg_mentor_nail_long_planned();
 EXPLAIN (COSTS OFF) EXECUTE qry(1); -- should be generic plan
 
-SELECT query, plan_cache_mode, calls
-FROM pg_stat_statements pgss, pg_mentor_show_managed_queries(-1) pgmq
-WHERE pgss.queryid = pgmq.queryid
+SELECT refcounter,calls,plan_cache_mode,query
+FROM show_entries()
 ORDER BY md5(query);
 
 DEALLOCATE ALL;


### PR DESCRIPTION
Previous attempt had an issue: we passed through all the pg_stat_statements entries and made decisions dispite the entry has never been prepared statement.

It is too expensive on productive machines. So, here we go the way of updating global HTAB on backend makes PREPARE. We introduce refcounter to watch how many backends uses similar prepared statement. Intercepting utility hook we manage this parameter by employing PREPARE/DEALLOCATE commands and before_shmem_exit callback.